### PR TITLE
Add support for Linksys MX4200v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-advanced-reboot
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 LUCI_TITLE:=Advanced Linksys Reboot Web UI
 LUCI_URL:=https://github.com/stangri/luci-app-advanced-reboot/

--- a/root/usr/share/advanced-reboot/devices/linksys-mx4200v2.json
+++ b/root/usr/share/advanced-reboot/devices/linksys-mx4200v2.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "MX4200v2",
+	"boardNames": [ "linksys,mx4200v2" ],
+	"partition1MTD": "mtd21",
+	"partition2MTD": "mtd23",
+	"labelOffset": 192,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}


### PR DESCRIPTION
It's basically the same as the MX4200v1

The ouput of the required commands is [here](https://forum.openwrt.org/t/web-ui-to-reboot-to-another-partition-for-linksys-zyxel-dual-partition-routers-and-to-power-off-power-down/3423/340?u=innovara).