### PR TITLE
Add support for Linksys MX2000 and MX5500

### DIFF
--- a/root/usr/share/advanced-reboot/devices/linksys-mx2000.json
+++ b/root/usr/share/advanced-reboot/devices/linksys-mx2000.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "MX2000",
+	"boardNames": [ "linksys,mx2000" ],
+	"partition1MTD": "mtd12",
+	"partition2MTD": "mtd14",
+	"labelOffset": 192,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}

--- a/root/usr/share/advanced-reboot/devices/linksys-mx5500.json
+++ b/root/usr/share/advanced-reboot/devices/linksys-mx5500.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "MX5500",
+	"boardNames": [ "linksys,mx5500" ],
+	"partition1MTD": "mtd12",
+	"partition2MTD": "mtd14",
+	"labelOffset": 192,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}


### PR DESCRIPTION
Add support for Linksys MX2000 and MX5500
Device support was upstreamed in this commit:
https://github.com/openwrt/openwrt/commit/398f4a97378e2f645badc1aef3d0e9fd76f6665d